### PR TITLE
Add releae workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+jobs:
+  build_and_release:
+    name: Create a release for rust project
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout and install dependencies
+      - uses: actions/checkout@v5
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+      - run: sudo apt install -y libwayland-dev wayland-protocols libxkbcommon-dev
+
+      - name: Build pwwwd
+        run: cargo build --release
+
+      - name: Build pwww
+        run: cargo build --release --package pwww
+
+      - name: Prepare artifacts
+        run: |
+          mkdir dist
+          cp target/release/pwwwd dist/pwwwd
+          cp target/release/pwww dist/pwww
+
+      - name: Create Github release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/pwwwd
+            dist/pwww
+          draft: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ repository = "https://github.com/NaviHX/pwwwd"
 license = "MIT"
 keywords = ["graphics", "wayland", "wallpaper"]
 
+[profile.release]
+strip = true
+lto = true
+
 [workspace]
 members = [
     "client",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -3,6 +3,10 @@ name = "pwww"
 version = "0.1.0"
 edition = "2024"
 
+[profile.release]
+strip = true
+lto = true
+
 [dependencies]
 anyhow = "1.0.100"
 clap = "4.5.53"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,6 +3,10 @@ name = "common"
 version = "0.1.0"
 edition = "2024"
 
+[profile.release]
+strip = true
+lto = true
+
 [dependencies]
 anyhow = "1.0.100"
 clap = { version = "4.5.53", features = ["derive"] }


### PR DESCRIPTION
Everytime we push a tag to the github repo, github action will automatically create a release draft. Artifacts (`pwwwd` and `pwww`) will be built and upload to this release draft.